### PR TITLE
Make defenders more strictly defenders, value archery and archers less early, use warriors as defenders more early instead, give earlier AI free techs, give AI early explorers at more difficulties, slightly increase human tech costs at mid-high difficulties (and even more slightly reduce them at highest difficulties)

### DIFF
--- a/Assets/XML/GameInfo/CIV4HandicapInfo.xml
+++ b/Assets/XML/GameInfo/CIV4HandicapInfo.xml
@@ -178,24 +178,29 @@
 					<TechType>TECH_DRAMA</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: optics should be more versatile than gunpowder, was TECH_GUNPOWDER -->
+				<FreeTech>
+					<TechType>TECH_OPTICS</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<!-- custom: gunpowder should be more versatile than steel plus is a sooner available tech, was TECH_STEEL -->
 				<FreeTech>
 					<TechType>TECH_GUNPOWDER</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: chemistry should be more useful to the player than steam power, and more early in the game, was TECH_STEAM_POWER -->
 				<FreeTech>
-					<TechType>TECH_STEAM_POWER</TechType>
+					<TechType>TECH_CHEMISTRY</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: industrialism should be more useful to the player than plastics, was TECH_PLASTICS -->
 				<FreeTech>
-					<TechType>TECH_STEEL</TechType>
+					<TechType>TECH_INDUSTRIALISM</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: biology should be more useful to the player than refrigeration, was TECH_REFRIGERATION -->
 				<FreeTech>
-					<TechType>TECH_PLASTICS</TechType>
-					<bFreeTech>1</bFreeTech>
-				</FreeTech>
-				<FreeTech>
-					<TechType>TECH_REFRIGERATION</TechType>
+					<TechType>TECH_BIOLOGY</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 			</FreeTechs>
@@ -361,12 +366,14 @@
 					<TechType>TECH_DRAMA</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: chemistry should be more useful to the player than steam power, and more early in the game, was TECH_STEAM_POWER -->
 				<FreeTech>
-					<TechType>TECH_STEAM_POWER</TechType>
+					<TechType>TECH_CHEMISTRY</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: industrialism should be more useful to the player than plastics, was TECH_PLASTICS -->
 				<FreeTech>
-					<TechType>TECH_PLASTICS</TechType>
+					<TechType>TECH_INDUSTRIALISM</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 			</FreeTechs>
@@ -943,12 +950,14 @@
 					<TechType>TECH_DRAMA</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: chemistry should be more useful to the player than steam power, and more early in the game, was TECH_STEAM_POWER -->
 				<FreeTech>
-					<TechType>TECH_STEAM_POWER</TechType>
+					<TechType>TECH_CHEMISTRY</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: industrialism should be more useful to the player than plastics, was TECH_PLASTICS -->
 				<FreeTech>
-					<TechType>TECH_PLASTICS</TechType>
+					<TechType>TECH_INDUSTRIALISM</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 			</AIFreeTechs>
@@ -1133,12 +1142,14 @@
 					<TechType>TECH_DRAMA</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: chemistry should be more useful to the player than steam power, and more early in the game, was TECH_STEAM_POWER -->
 				<FreeTech>
-					<TechType>TECH_STEAM_POWER</TechType>
+					<TechType>TECH_CHEMISTRY</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: industrialism should be more useful to the player than plastics, was TECH_PLASTICS -->
 				<FreeTech>
-					<TechType>TECH_PLASTICS</TechType>
+					<TechType>TECH_INDUSTRIALISM</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 			</AIFreeTechs>
@@ -1345,12 +1356,14 @@
 					<TechType>TECH_DRAMA</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: chemistry should be more useful to the player than steam power, and more early in the game, was TECH_STEAM_POWER -->
 				<FreeTech>
-					<TechType>TECH_STEAM_POWER</TechType>
+					<TechType>TECH_CHEMISTRY</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: industrialism should be more useful to the player than plastics, was TECH_PLASTICS -->
 				<FreeTech>
-					<TechType>TECH_PLASTICS</TechType>
+					<TechType>TECH_INDUSTRIALISM</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 			</AIFreeTechs>
@@ -1571,24 +1584,29 @@
 					<TechType>TECH_DRAMA</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: optics should be more versatile than gunpowder, was TECH_GUNPOWDER -->
+				<FreeTech>
+					<TechType>TECH_OPTICS</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<!-- custom: gunpowder should be more versatile than steel plus is a sooner available tech, was TECH_STEEL -->
 				<FreeTech>
 					<TechType>TECH_GUNPOWDER</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: chemistry should be more useful to the player than steam power, and more early in the game, was TECH_STEAM_POWER -->
 				<FreeTech>
-					<TechType>TECH_STEAM_POWER</TechType>
+					<TechType>TECH_CHEMISTRY</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: industrialism should be more useful to the player than plastics, was TECH_PLASTICS -->
 				<FreeTech>
-					<TechType>TECH_STEEL</TechType>
+					<TechType>TECH_INDUSTRIALISM</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: biology should be more useful to the player than refrigeration, was TECH_REFRIGERATION -->
 				<FreeTech>
-					<TechType>TECH_PLASTICS</TechType>
-					<bFreeTech>1</bFreeTech>
-				</FreeTech>
-				<FreeTech>
-					<TechType>TECH_REFRIGERATION</TechType>
+					<TechType>TECH_BIOLOGY</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 			</AIFreeTechs>

--- a/Assets/XML/GameInfo/CIV4HandicapInfo.xml
+++ b/Assets/XML/GameInfo/CIV4HandicapInfo.xml
@@ -1056,6 +1056,11 @@
 					<TechType>TECH_HUNTING</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: also add fishing to help/speed up early AI growth (they would also not spend time thus on such techs)-->
+				<FreeTech>
+					<TechType>TECH_FISHING</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
 				<!-- custom: further discourage AIs to build archers early, they are not versatile enough.
 				             If AI wants to turtle later in the game, archers may be more relevant then.
 							 Else, upgraded versions of warriors would give more of a military advantage for the AI if it wants to attack instead.
@@ -1239,6 +1244,15 @@
 					<TechType>TECH_HUNTING</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: also add fishing and mysticism to help/speed up early AI growth (they would also not spend time thus on such techs)-->
+				<FreeTech>
+					<TechType>TECH_FISHING</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<FreeTech>
+					<TechType>TECH_MYSTICISM</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
 				<!-- custom: further discourage AIs to build archers early, they are not versatile enough.
 				             If AI wants to turtle later in the game, archers may be more relevant then.
 							 Else, upgraded versions of warriors would give more of a military advantage for the AI if it wants to attack instead.
@@ -1251,6 +1265,17 @@
 				<!-- custom: instead, give them a tech that helps them expand more early -->
 				<FreeTech>
 					<TechType>TECH_POTTERY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<!-- custom: give a bunch of smaller (animal husbandry) key or very optional techs rather than a few big ones.
+				It may make the early game more gradual while still having the AI not waste as much time on less rewarding techs.
+				, was IRON_WORKING-->
+				<FreeTech>
+					<TechType>TECH_ANIMAL_HUSBANDRY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<FreeTech>
+					<TechType>TECH_BRONZE_WORKING</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>
@@ -1432,6 +1457,15 @@
 					<TechType>TECH_HUNTING</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: also add fishing and mysticism to help/speed up early AI growth (they would also not spend time thus on such techs)-->
+				<FreeTech>
+					<TechType>TECH_FISHING</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<FreeTech>
+					<TechType>TECH_MYSTICISM</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
 				<!-- custom: further discourage AIs to build archers early, they are not versatile enough.
 				             If AI wants to turtle later in the game, archers may be more relevant then.
 							 Else, upgraded versions of warriors would give more of a military advantage for the AI if it wants to attack instead.
@@ -1450,8 +1484,15 @@
 					<TechType>TECH_MATHEMATICS</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: give a bunch of smaller (bronze working and animal husbandry) key or very optional techs rather than a few big ones.
+				It may make the early game more gradual while still having the AI not waste as much time on less rewarding techs.
+				, was IRON_WORKING-->
 				<FreeTech>
-					<TechType>TECH_IRON_WORKING</TechType>
+					<TechType>TECH_ANIMAL_HUSBANDRY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<FreeTech>
+					<TechType>TECH_BRONZE_WORKING</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>

--- a/Assets/XML/GameInfo/CIV4HandicapInfo.xml
+++ b/Assets/XML/GameInfo/CIV4HandicapInfo.xml
@@ -885,14 +885,12 @@
 			<FreeTechs/>
 			<AIFreeTechs>
 				<!-- custom: further discourage AIs to build archers early, they are not versatile enough.
-				             If AI wants to turtle later in the game, archers may be more relevant then.
-							 Else, upgraded versions of warriors would give more of a military advantage for the AI if it wants to attack instead.
-				-->
+				If AI wants to turtle later in the game, archers may be more relevant then.
+				Else, upgraded versions of warriors would give more of a military advantage for the AI if it wants to attack instead.-->
 				<!--<FreeTech>
 					<TechType>TECH_ARCHERY</TechType>
 					<bFreeTech>1</bFreeTech>
-				</FreeTech>
-				-->
+				</FreeTech>-->
 				<!-- custom: instead, give them a tech that helps them expand more early -->
 				<FreeTech>
 					<TechType>TECH_POTTERY</TechType>
@@ -1068,14 +1066,12 @@
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<!-- custom: further discourage AIs to build archers early, they are not versatile enough.
-				             If AI wants to turtle later in the game, archers may be more relevant then.
-							 Else, upgraded versions of warriors would give more of a military advantage for the AI if it wants to attack instead.
-				-->
+				If AI wants to turtle later in the game, archers may be more relevant then.
+				Else, upgraded versions of warriors would give more of a military advantage for the AI if it wants to attack instead.-->
 				<!--<FreeTech>
 					<TechType>TECH_ARCHERY</TechType>
 					<bFreeTech>1</bFreeTech>
-				</FreeTech>
-				-->
+				</FreeTech>-->
 				<!-- custom: instead, give them a tech that helps them expand more early -->
 				<FreeTech>
 					<TechType>TECH_POTTERY</TechType>
@@ -1262,14 +1258,12 @@
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<!-- custom: further discourage AIs to build archers early, they are not versatile enough.
-				             If AI wants to turtle later in the game, archers may be more relevant then.
-							 Else, upgraded versions of warriors would give more of a military advantage for the AI if it wants to attack instead.
-				-->
+				If AI wants to turtle later in the game, archers may be more relevant then.
+				Else, upgraded versions of warriors would give more of a military advantage for the AI if it wants to attack instead.-->
 				<!--<FreeTech>
 					<TechType>TECH_ARCHERY</TechType>
 					<bFreeTech>1</bFreeTech>
-				</FreeTech>
-				-->
+				</FreeTech>-->
 				<!-- custom: instead, give them a tech that helps them expand more early -->
 				<FreeTech>
 					<TechType>TECH_POTTERY</TechType>
@@ -1475,14 +1469,12 @@
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<!-- custom: further discourage AIs to build archers early, they are not versatile enough.
-				             If AI wants to turtle later in the game, archers may be more relevant then.
-							 Else, upgraded versions of warriors would give more of a military advantage for the AI if it wants to attack instead.
-				-->
+				If AI wants to turtle later in the game, archers may be more relevant then.
+				Else, upgraded versions of warriors would give more of a military advantage for the AI if it wants to attack instead.-->
 				<!--<FreeTech>
 					<TechType>TECH_ARCHERY</TechType>
 					<bFreeTech>1</bFreeTech>
-				</FreeTech>
-				-->
+				</FreeTech>-->
 				<!-- custom: instead, give them a tech that helps them expand more early -->
 				<FreeTech>
 					<TechType>TECH_POTTERY</TechType>

--- a/Assets/XML/GameInfo/CIV4HandicapInfo.xml
+++ b/Assets/XML/GameInfo/CIV4HandicapInfo.xml
@@ -155,16 +155,27 @@
 					<TechType>TECH_ALPHABET</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: monarchy should help more early with new regime, wine happiness (and trade possibility maybe too?),
+				and possibility also to research feudalism sooner, machinery may not be so useful for the AI early even if it costs more,
+				was TECH_MACHINERY-->
 				<FreeTech>
-					<TechType>TECH_MACHINERY</TechType>
+					<TechType>TECH_MONARCHY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<!-- custom: currency should greatly help early, perhaps about as much as feudalism but still leaving a chance for
+				the human player to catch up due to lower cost of this tech-->
+				<FreeTech>
+					<TechType>TECH_CURRENCY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<!-- custom: giving them sooner to the player so they don't lose turns to search it nor extra cost for it, 
+				also may be more versatile than printing press, was PRINTING_PRESS-->
+				<FreeTech>
+					<TechType>TECH_COMPASS</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>
-					<TechType>TECH_FEUDALISM</TechType>
-					<bFreeTech>1</bFreeTech>
-				</FreeTech>
-				<FreeTech>
-					<TechType>TECH_PRINTING_PRESS</TechType>
+					<TechType>TECH_DRAMA</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>
@@ -327,12 +338,27 @@
 					<TechType>TECH_MATHEMATICS</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: monarchy should help more early with new regime, wine happiness (and trade possibility maybe too?),
+				and possibility also to research feudalism sooner, machinery may not be so useful for the AI early even if it costs more,
+				was TECH_MACHINERY-->
 				<FreeTech>
-					<TechType>TECH_MACHINERY</TechType>
+					<TechType>TECH_MONARCHY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<!-- custom: currency should greatly help early, perhaps about as much as feudalism but still leaving a chance for
+				the human player to catch up due to lower cost of this tech-->
+				<FreeTech>
+					<TechType>TECH_CURRENCY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<!-- custom: giving them sooner to the player so they don't lose turns to search it nor extra cost for it, 
+				also may be more versatile than printing press, was PRINTING_PRESS-->
+				<FreeTech>
+					<TechType>TECH_COMPASS</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>
-					<TechType>TECH_PRINTING_PRESS</TechType>
+					<TechType>TECH_DRAMA</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>
@@ -900,12 +926,21 @@
 					<TechType>TECH_MATHEMATICS</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: monarchy should help the AI more early with new regime, wine happiness (and trade possibility maybe too?),
+				and possibility also to research feudalism sooner, machinery may not be so useful for the AI early even if it costs more,
+				was TECH_MACHINERY-->
 				<FreeTech>
-					<TechType>TECH_MACHINERY</TechType>
+					<TechType>TECH_MONARCHY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<!-- custom: giving them sooner to the player so they don't lose turns to search it nor extra cost for it, 
+				also may be more versatile than printing press, was PRINTING_PRESS-->
+				<FreeTech>
+					<TechType>TECH_COMPASS</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>
-					<TechType>TECH_PRINTING_PRESS</TechType>
+					<TechType>TECH_DRAMA</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>
@@ -1081,12 +1116,21 @@
 					<TechType>TECH_MATHEMATICS</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: monarchy should help the AI more early with new regime, wine happiness (and trade possibility maybe too?),
+				and possibility also to research feudalism sooner, machinery may not be so useful for the AI early even if it costs more,
+				was TECH_MACHINERY-->
 				<FreeTech>
-					<TechType>TECH_MACHINERY</TechType>
+					<TechType>TECH_MONARCHY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<!-- custom: giving them sooner to the player so they don't lose turns to search it nor extra cost for it, 
+				also may be more versatile than printing press, was PRINTING_PRESS-->
+				<FreeTech>
+					<TechType>TECH_COMPASS</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>
-					<TechType>TECH_PRINTING_PRESS</TechType>
+					<TechType>TECH_DRAMA</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>
@@ -1284,12 +1328,21 @@
 					<TechType>TECH_MATHEMATICS</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: monarchy should help the AI more early with new regime, wine happiness (and trade possibility maybe too?),
+				and possibility also to research feudalism sooner, machinery may not be so useful for the AI early even if it costs more,
+				was TECH_MACHINERY-->
 				<FreeTech>
-					<TechType>TECH_MACHINERY</TechType>
+					<TechType>TECH_MONARCHY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<!-- custom: giving them sooner to the player so they don't lose turns to search it nor extra cost for it, 
+				also may be more versatile than printing press, was PRINTING_PRESS-->
+				<FreeTech>
+					<TechType>TECH_COMPASS</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>
-					<TechType>TECH_PRINTING_PRESS</TechType>
+					<TechType>TECH_DRAMA</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>
@@ -1495,16 +1548,27 @@
 					<TechType>TECH_BRONZE_WORKING</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
+				<!-- custom: monarchy should help the AI more early with new regime, wine happiness (and trade possibility maybe too?),
+				and possibility also to research feudalism sooner, machinery may not be so useful for the AI early even if it costs more,
+				was TECH_MACHINERY-->
 				<FreeTech>
-					<TechType>TECH_MACHINERY</TechType>
+					<TechType>TECH_MONARCHY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<!-- custom: currency should greatly help early the AI, perhaps about as much as feudalism but still leaving a chance for
+				the human player to catch up due to lower cost of this tech-->
+				<FreeTech>
+					<TechType>TECH_CURRENCY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				<!-- custom: giving them sooner to the player so they don't lose turns to search it nor extra cost for it, 
+				also may be more versatile than printing press, was PRINTING_PRESS-->
+				<FreeTech>
+					<TechType>TECH_COMPASS</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>
-					<TechType>TECH_FEUDALISM</TechType>
-					<bFreeTech>1</bFreeTech>
-				</FreeTech>
-				<FreeTech>
-					<TechType>TECH_PRINTING_PRESS</TechType>
+					<TechType>TECH_DRAMA</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>

--- a/Assets/XML/GameInfo/CIV4HandicapInfo.xml
+++ b/Assets/XML/GameInfo/CIV4HandicapInfo.xml
@@ -662,7 +662,8 @@
 			<iGPThresholdPercent>100</iGPThresholdPercent>
 			<iCultureLevelPercent>100</iCultureLevelPercent>
 			<!-- was 110 -->
-			<iResearchPercent>108</iResearchPercent>
+			<!-- custom: make the gap between human and AI tech costs closer to in higher difficulties, was 108-->
+			<iResearchPercent>110</iResearchPercent>
 			<iTrainPercent>100</iTrainPercent>
 			<iConstructPercent>100</iConstructPercent>
 			<iCreatePercent>100</iCreatePercent>
@@ -799,7 +800,8 @@
 			<iGPThresholdPercent>100</iGPThresholdPercent>
 			<iCultureLevelPercent>106</iCultureLevelPercent>
 			<!-- was 120 -->
-			<iResearchPercent>115</iResearchPercent>
+            <!-- custom: make the gap between human and AI tech costs closer to in higher difficulties, was 115-->
+			<iResearchPercent>119</iResearchPercent>
 			<!-- advc.251 (end) -->
 			<!-- advc.251 (start) -->
 			<iTrainPercent>100</iTrainPercent>
@@ -984,7 +986,8 @@
 			<iBaseGrowthThresholdPercent>110</iBaseGrowthThresholdPercent>
 			<iGPThresholdPercent>110</iGPThresholdPercent>
 			<iCultureLevelPercent>112</iCultureLevelPercent>
-			<iResearchPercent>130</iResearchPercent>
+			<!-- custom: make the gap between human and AI tech costs closer to in higher difficulties, was 130-->
+			<iResearchPercent>132</iResearchPercent>
 			<iTrainPercent>110</iTrainPercent>
 			<iConstructPercent>105</iConstructPercent>
 			<iCreatePercent>100</iCreatePercent>
@@ -1177,7 +1180,8 @@
 			<iGPThresholdPercent>120</iGPThresholdPercent>
 			<iCultureLevelPercent>118</iCultureLevelPercent>
 			<!-- was 125 -->
-			<iResearchPercent>140</iResearchPercent>
+			<!-- custom: slightly reduce human costs due to AI having more earlier techs now, was 140-->
+			<iResearchPercent>135</iResearchPercent>
 			<iTrainPercent>120</iTrainPercent>
 			<iConstructPercent>110</iConstructPercent>
 			<iCreatePercent>110</iCreatePercent>
@@ -1390,7 +1394,8 @@
 			<iGPThresholdPercent>130</iGPThresholdPercent>
 			<iCultureLevelPercent>129</iCultureLevelPercent>
 			<!-- advc.251: was 130 -->
-			<iResearchPercent>150</iResearchPercent>
+			<!-- custom: slightly reduce human costs due to AI having more earlier techs now, was 150-->
+			<iResearchPercent>145</iResearchPercent>
 			<iTrainPercent>130</iTrainPercent>
 			<iConstructPercent>115</iConstructPercent>
 			<iCreatePercent>120</iCreatePercent>

--- a/Assets/XML/GameInfo/CIV4HandicapInfo.xml
+++ b/Assets/XML/GameInfo/CIV4HandicapInfo.xml
@@ -1493,7 +1493,7 @@
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<!-- custom: give a bunch of smaller (bronze working and animal husbandry) key or very optional techs rather than a few big ones.
-				It may make the early game more gradual while still having the AI not waste as much time on less rewarding techs.
+				It may make the early game more gradual while still having the human not waste as much time on less rewarding techs.
 				, was IRON_WORKING-->
 				<FreeTech>
 					<TechType>TECH_ANIMAL_HUSBANDRY</TechType>

--- a/Assets/XML/GameInfo/CIV4HandicapInfo.xml
+++ b/Assets/XML/GameInfo/CIV4HandicapInfo.xml
@@ -680,7 +680,8 @@
 			<iStartingWorkerUnits>0</iStartingWorkerUnits>
 			<iStartingExploreUnits>0</iStartingExploreUnits>
 			<iAIStartingUnitMultiplier>0</iAIStartingUnitMultiplier>
-			<iAIStartingDefenseUnits>0</iAIStartingDefenseUnits>
+			<!-- custom: assuming warriors are enforced rather than archers, the number of units needs to be increased, was 0 -->
+			<iAIStartingDefenseUnits>1</iAIStartingDefenseUnits>
 			<iAIStartingWorkerUnits>0</iAIStartingWorkerUnits>
 			<iAIStartingExploreUnits>0</iAIStartingExploreUnits>
 			<iBarbarianDefenders>2</iBarbarianDefenders>
@@ -817,7 +818,8 @@
 			<iStartingWorkerUnits>0</iStartingWorkerUnits>
 			<iStartingExploreUnits>0</iStartingExploreUnits>
 			<iAIStartingUnitMultiplier>0</iAIStartingUnitMultiplier>
-			<iAIStartingDefenseUnits>1</iAIStartingDefenseUnits>
+			<!-- custom: assuming warriors are enforced rather than archers, the number of units needs to be increased, was 1 -->
+			<iAIStartingDefenseUnits>2</iAIStartingDefenseUnits>
 			<iAIStartingWorkerUnits>0</iAIStartingWorkerUnits>
 			<iAIStartingExploreUnits>0</iAIStartingExploreUnits>
 			<iBarbarianDefenders>3</iBarbarianDefenders>
@@ -878,8 +880,18 @@
 			</Goodies>
 			<FreeTechs/>
 			<AIFreeTechs>
-				<FreeTech>
+				<!-- custom: further discourage AIs to build archers early, they are not versatile enough.
+				             If AI wants to turtle later in the game, archers may be more relevant then.
+							 Else, upgraded versions of warriors would give more of a military advantage for the AI if it wants to attack instead.
+				-->
+				<!--<FreeTech>
 					<TechType>TECH_ARCHERY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				-->
+				<!-- custom: instead, give them a tech that helps them expand more early -->
+				<FreeTech>
+					<TechType>TECH_POTTERY</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>
@@ -975,6 +987,7 @@
 			<iStartingWorkerUnits>0</iStartingWorkerUnits>
 			<iStartingExploreUnits>0</iStartingExploreUnits>
 			<iAIStartingUnitMultiplier>0</iAIStartingUnitMultiplier>
+			<!-- custom: assuming warriors are enforced rather than archers, the number of units needs to be increased, was 1 -->
 			<iAIStartingDefenseUnits>2</iAIStartingDefenseUnits>
 			<iAIStartingWorkerUnits>0</iAIStartingWorkerUnits>
 			<!-- advc.250e: was 1 -->
@@ -1043,8 +1056,18 @@
 					<TechType>TECH_HUNTING</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
-				<FreeTech>
+				<!-- custom: further discourage AIs to build archers early, they are not versatile enough.
+				             If AI wants to turtle later in the game, archers may be more relevant then.
+							 Else, upgraded versions of warriors would give more of a military advantage for the AI if it wants to attack instead.
+				-->
+				<!--<FreeTech>
 					<TechType>TECH_ARCHERY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				-->
+				<!-- custom: instead, give them a tech that helps them expand more early -->
+				<FreeTech>
+					<TechType>TECH_POTTERY</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>
@@ -1143,7 +1166,8 @@
 			<iStartingExploreUnits>0</iStartingExploreUnits>
 			<iAIStartingUnitMultiplier>0</iAIStartingUnitMultiplier>
 			<!-- advc.250e: was 3 -->
-			<iAIStartingDefenseUnits>2</iAIStartingDefenseUnits>
+			<!-- custom: assuming warriors are enforced rather than archers, the number of units needs to be increased, was 2 -->
+			<iAIStartingDefenseUnits>4</iAIStartingDefenseUnits>
 			<iAIStartingWorkerUnits>1</iAIStartingWorkerUnits>
 			<!-- advc.250e: was 1 -->
 			<iAIStartingExploreUnits>0</iAIStartingExploreUnits>
@@ -1215,8 +1239,18 @@
 					<TechType>TECH_HUNTING</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
-				<FreeTech>
+				<!-- custom: further discourage AIs to build archers early, they are not versatile enough.
+				             If AI wants to turtle later in the game, archers may be more relevant then.
+							 Else, upgraded versions of warriors would give more of a military advantage for the AI if it wants to attack instead.
+				-->
+				<!--<FreeTech>
 					<TechType>TECH_ARCHERY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				-->
+				<!-- custom: instead, give them a tech that helps them expand more early -->
+				<FreeTech>
+					<TechType>TECH_POTTERY</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>
@@ -1318,7 +1352,8 @@
 			<!-- advc.250e: was 1 -->
 			<iAIStartingUnitMultiplier>0</iAIStartingUnitMultiplier>
 			<!-- advc.250e: was 4 -->
-			<iAIStartingDefenseUnits>3</iAIStartingDefenseUnits>
+			<!-- custom: assuming warriors are enforced rather than archers, the number of units needs to be increased, was 3 -->
+			<iAIStartingDefenseUnits>6</iAIStartingDefenseUnits>
 			<iAIStartingWorkerUnits>1</iAIStartingWorkerUnits>
 			<iAIStartingExploreUnits>1</iAIStartingExploreUnits>
 			<iBarbarianDefenders>4</iBarbarianDefenders>
@@ -1397,8 +1432,18 @@
 					<TechType>TECH_HUNTING</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
-				<FreeTech>
+				<!-- custom: further discourage AIs to build archers early, they are not versatile enough.
+				             If AI wants to turtle later in the game, archers may be more relevant then.
+							 Else, upgraded versions of warriors would give more of a military advantage for the AI if it wants to attack instead.
+				-->
+				<!--<FreeTech>
 					<TechType>TECH_ARCHERY</TechType>
+					<bFreeTech>1</bFreeTech>
+				</FreeTech>
+				-->
+				<!-- custom: instead, give them a tech that helps them expand more early -->
+				<FreeTech>
+					<TechType>TECH_POTTERY</TechType>
 					<bFreeTech>1</bFreeTech>
 				</FreeTech>
 				<FreeTech>

--- a/Assets/XML/GameInfo/CIV4HandicapInfo.xml
+++ b/Assets/XML/GameInfo/CIV4HandicapInfo.xml
@@ -683,7 +683,9 @@
 			<!-- custom: assuming warriors are enforced rather than archers, the number of units needs to be increased, was 0 -->
 			<iAIStartingDefenseUnits>1</iAIStartingDefenseUnits>
 			<iAIStartingWorkerUnits>0</iAIStartingWorkerUnits>
-			<iAIStartingExploreUnits>0</iAIStartingExploreUnits>
+			<!-- custom: no reason and a bit excessive i think to not give a free scout at higher difficulties, especially considering
+			warriors are now more likely to be defenders, was 0 -->
+			<iAIStartingExploreUnits>1</iAIStartingExploreUnits>
 			<iBarbarianDefenders>2</iBarbarianDefenders>
 			<iAIDeclareWarProb>100</iAIDeclareWarProb>
 			<!-- advc.251: was 10 -->
@@ -821,7 +823,9 @@
 			<!-- custom: assuming warriors are enforced rather than archers, the number of units needs to be increased, was 1 -->
 			<iAIStartingDefenseUnits>2</iAIStartingDefenseUnits>
 			<iAIStartingWorkerUnits>0</iAIStartingWorkerUnits>
-			<iAIStartingExploreUnits>0</iAIStartingExploreUnits>
+			<!-- custom: no reason and a bit excessive i think to not give a free scout at higher difficulties, especially considering
+			warriors are now more likely to be defenders, was 0 -->
+			<iAIStartingExploreUnits>1</iAIStartingExploreUnits>
 			<iBarbarianDefenders>3</iBarbarianDefenders>
 			<iAIDeclareWarProb>100</iAIDeclareWarProb>
 			<!-- advc.251: was 20 -->
@@ -991,7 +995,9 @@
 			<iAIStartingDefenseUnits>2</iAIStartingDefenseUnits>
 			<iAIStartingWorkerUnits>0</iAIStartingWorkerUnits>
 			<!-- advc.250e: was 1 -->
-			<iAIStartingExploreUnits>0</iAIStartingExploreUnits>
+			<!-- custom: no reason and a bit excessive i think to not give a free scout at higher difficulties, especially considering
+			warriors are now more likely to be defenders, was 0 -->
+			<iAIStartingExploreUnits>1</iAIStartingExploreUnits>
 			<iBarbarianDefenders>3</iBarbarianDefenders>
 			<iAIDeclareWarProb>100</iAIDeclareWarProb>
 			<!-- advc.251: was 50 -->
@@ -1175,7 +1181,9 @@
 			<iAIStartingDefenseUnits>4</iAIStartingDefenseUnits>
 			<iAIStartingWorkerUnits>1</iAIStartingWorkerUnits>
 			<!-- advc.250e: was 1 -->
-			<iAIStartingExploreUnits>0</iAIStartingExploreUnits>
+			<!-- custom: no reason and a bit excessive i think to not give a free scout at higher difficulties, especially considering
+			warriors are now more likely to be defenders, was 0 -->
+			<iAIStartingExploreUnits>1</iAIStartingExploreUnits>
 			<!-- advc.250e: was 4 -->
 			<iBarbarianDefenders>3</iBarbarianDefenders>
 			<iAIDeclareWarProb>100</iAIDeclareWarProb>

--- a/Assets/XML/Technologies/CIV4TechInfos.xml
+++ b/Assets/XML/Technologies/CIV4TechInfos.xml
@@ -675,7 +675,10 @@
 			<Strategy>TXT_KEY_TECH_FEUDALISM_STRATEGY</Strategy>
 			<Advisor>ADVISOR_ECONOMY</Advisor>
 			<!-- advc.131b -->
-			<iAIWeight>-125</iAIWeight>
+			<!-- custom: not a problem if they search feudalism too soon or too often, it is a strong tech that helps both military and economy, was -125.
+					     The history relevance is not a problem to me, much more military performance of choosing a more effective tech (than machinery would be before that)
+			-->
+			<iAIWeight>0</iAIWeight>
 			<iAITradeModifier>10</iAITradeModifier>
 			<!-- advc.910: was 700 -->
 			<iCost>820</iCost>
@@ -2097,7 +2100,9 @@
 			<Help/>
 			<Strategy>TXT_KEY_TECH_POTTERY_STRATEGY</Strategy>
 			<Advisor>ADVISOR_ECONOMY</Advisor>
-			<iAIWeight>0</iAIWeight>
+			<!-- custom: if AI does not get pottery as a free tech, it is however still a quite important tech. Getting cottages or/and
+			starting to build a granary sooner should help the AI, although not as much (i think) as more military or expansion focused techs -->
+			<iAIWeight>20</iAIWeight>
 			<iAITradeModifier>0</iAITradeModifier>
 			<iCost>80</iCost>
 			<iAdvancedStartCost>100</iAdvancedStartCost>
@@ -2243,7 +2248,9 @@
 			<Strategy>TXT_KEY_TECH_SAILING_STRATEGY</Strategy>
 			<Advisor>ADVISOR_GROWTH</Advisor>
 			<!-- advc.131b -->
-			<iAIWeight>-100</iAIWeight>
+			<!-- custom: if AIs want to get an early lighthouse or/and moai or/and galleys, it may not be so useless in some contexts
+			Rebalance the priorities of techs elsewhere (such as in free tech handicaps for example) , was -100 -->
+			<iAIWeight>-20</iAIWeight>
 			<iAITradeModifier>0</iAITradeModifier>
 			<!-- advc.301 -->
 			<iBarbarianFreeTechModifier>-50</iBarbarianFreeTechModifier>
@@ -4500,7 +4507,16 @@
 			<Help/>
 			<Strategy>TXT_KEY_TECH_ARCHERY_STRATEGY</Strategy>
 			<Advisor>ADVISOR_MILITARY</Advisor>
-			<iAIWeight>0</iAIWeight>
+			<!--custom: archery should be much less important to AIs now that they start with the more versatile warriors,
+			it should maybe be important if AI is getting behind in military power or/and adopting turtle strategy, else it may
+			be fine to wait until feudalism is discovered if the AI then wants longbowmen.
+			Axemen and similar units should be good enough defenders, adding swordsmen or/and chariots or spearmen should also help
+			balance out all this for more AI early versatility.
+			Archers are also quite bad at rushing another AI early, and wars do not seem to happen too soon so maybe wait until chariots
+			or/and spearmen or/and axemen are available before building rush units.
+			In short, if AI is weaker only then archers are relevant, else focus on versatility rather and warriors and their upgrades instead.
+			, was 0-->
+			<iAIWeight>-80</iAIWeight>
 			<!-- advc.552: was 10 -->
 			<iAITradeModifier>0</iAITradeModifier>
 			<iCost>60</iCost>
@@ -4648,7 +4664,10 @@
 			<Help/>
 			<Strategy>TXT_KEY_TECH_ANIMAL_HUSBANDRY_STRATEGY</Strategy>
 			<Advisor>ADVISOR_GROWTH</Advisor>
-			<iAIWeight>0</iAIWeight>
+			<!-- custom: if AIs value bronze working more now, so would be the counter to axemen (which is chariots).
+			Animal husbandry should also help revealing horse planting spots sooner to have better city locations, and getting pastures
+			sooner on relevant ressources to help growth and production, therefore i put a higher weight than for bronze working -->
+			<iAIWeight>50</iAIWeight>
 			<iAITradeModifier>0</iAITradeModifier>
 			<iCost>100</iCost>
 			<iAdvancedStartCost>100</iAdvancedStartCost>
@@ -4730,7 +4749,9 @@
 			<Help/>
 			<Strategy>TXT_KEY_TECH_BRONZE_WORKING_STRATEGY</Strategy>
 			<Advisor>ADVISOR_MILITARY</Advisor>
-			<iAIWeight>0</iAIWeight>
+			<!-- custom: bronze working is extra important to get early on, to upgrade the warrior free defenders into axemen at higher difficulties, or to
+			know more optimal city spots (that include copper) sooner, among other possible reasons -->
+			<iAIWeight>30</iAIWeight>
 			<iAITradeModifier>0</iAITradeModifier>
 			<iCost>120</iCost>
 			<iAdvancedStartCost>100</iAdvancedStartCost>
@@ -4884,7 +4905,8 @@
 			<Strategy>TXT_KEY_TECH_IRON_WORKING_STRATEGY</Strategy>
 			<Advisor>ADVISOR_MILITARY</Advisor>
 			<!-- advc.131b -->
-			<iAIWeight>-30</iAIWeight>
+			<!-- custom: if AIs badly want to get iron working, no reason to prevent that, was -30 -->
+			<iAIWeight>0</iAIWeight>
 			<iAITradeModifier>0</iAITradeModifier>
 			<!-- advc.131b: was 200 -->
 			<iCost>210</iCost>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -6875,19 +6875,11 @@
 			<FlankingStrikes/>
 			<UnitAIs>
 				<UnitAI>
-					<UnitAIType>UNITAI_RESERVE</UnitAIType>
+					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
-				<UnitAI>
-					<UnitAIType>UNITAI_COUNTER</UnitAIType>
-					<bUnitAI>1</bUnitAI>
-				</UnitAI>
-				<UnitAI>
-					<UnitAIType>UNITAI_CITY_COUNTER</UnitAIType>
-					<bUnitAI>1</bUnitAI>
-				</UnitAI>
-			</UnitAIs>
-			<NotUnitAIs/>
+			</UnitAIs>---------------------------------------
+			</NotUnitAIs />
 			<Builds/>
 			<ReligionSpreads/>
 			<CorporationSpreads/>
@@ -7396,7 +7388,9 @@
 			<Capture>NONE</Capture>
 			<Combat>UNITCOMBAT_MELEE</Combat>
 			<Domain>DOMAIN_LAND</Domain>
-			<DefaultUnitAI>UNITAI_COUNTER</DefaultUnitAI>
+			<!-- custom: pikemen are valuable as defenders, especially against knights and similar mounted units
+			, was _COUNTER-->
+			<DefaultUnitAI>UNITAI_CITY_DEFENSE</DefaultUnitAI>
 			<Invisible>NONE</Invisible>
 			<SeeInvisible>NONE</SeeInvisible>
 			<Description>TXT_KEY_UNIT_PIKEMAN</Description>
@@ -7454,6 +7448,15 @@
 			<FlankingStrikes/>
 			<UnitAIs>
 				<UnitAI>
+					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+			</UnitAIs>
+			<!-- custom: value pikemen more as city defenders, also the rock paper scissors logic when attacking a unit a group
+			makes it more likely that the pikeman would be wasted (or not used as optimally) while attacking a unit it is less good
+			against rather than defending (especially defending cities) against units it is very good against-->
+			<NotUnitAIs>
+				<UnitAI>
 					<UnitAIType>UNITAI_RESERVE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
@@ -7465,8 +7468,25 @@
 					<UnitAIType>UNITAI_CITY_COUNTER</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
-			</UnitAIs>
-			<NotUnitAIs/>
+				<!-- custom: added a few other AI unit types to be extra safe they are strictly defenders (for more war performance, to avoid
+				suicides and war wastes in particular, at the cost of versatility)-->
+				<UnitAI>
+					<UnitAIType>UNITAI_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_PILLAGE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+			</NotUnitAIs>
 			<Builds/>
 			<ReligionSpreads/>
 			<CorporationSpreads/>
@@ -7584,7 +7604,9 @@
 			<Capture>NONE</Capture>
 			<Combat>UNITCOMBAT_MELEE</Combat>
 			<Domain>DOMAIN_LAND</Domain>
-			<DefaultUnitAI>UNITAI_COUNTER</DefaultUnitAI>
+			<!-- custom: pikemen are valuable as defenders, especially against knights and similar mounted units
+			, was _COUNTER-->
+			<DefaultUnitAI>UNITAI_CITY_DEFENSE</DefaultUnitAI>
 			<Invisible>NONE</Invisible>
 			<SeeInvisible>NONE</SeeInvisible>
 			<Description>TXT_KEY_UNIT_HOLY_ROMAN_LANDSKNECHT</Description>
@@ -7640,9 +7662,10 @@
 			<UnitClassDefenders/>
 			<UnitCombatDefenders/>
 			<FlankingStrikes/>
-			<UnitAIs>
+			<!-- custom: make pikemen more strictly defenders, to increase military effectiveness at the cost of versatility -->
+			<!-- <UnitAIs> -->
 				<!-- K-Mod -->
-				<UnitAI>
+				<!--<UnitAI>
 					<UnitAIType>UNITAI_ATTACK</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
@@ -7659,7 +7682,48 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<NotUnitAIs/>
+			<NotUnitAIs/>-->
+			<UnitAIs>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+			</UnitAIs>
+			<!-- custom: value pikemen more as city defenders, also the rock paper scissors logic when attacking a unit a group
+			makes it more likely that the pikeman would be wasted (or not used as optimally) while attacking a unit it is less good
+			against rather than defending (especially defending cities) against units it is very good against-->
+			<NotUnitAIs>
+				<UnitAI>
+					<UnitAIType>UNITAI_RESERVE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<!-- custom: added a few other AI unit types to be extra safe they are strictly defenders (for more war performance, to avoid
+				suicides and war wastes in particular, at the cost of versatility)-->
+				<UnitAI>
+					<UnitAIType>UNITAI_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_PILLAGE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+			</NotUnitAIs>
 			<Builds/>
 			<ReligionSpreads/>
 			<CorporationSpreads/>
@@ -10683,15 +10747,18 @@
 			<FlankingStrikes/>
 			<UnitAIs>
 				<UnitAI>
-					<UnitAIType>UNITAI_ATTACK</UnitAIType>
-					<bUnitAI>1</bUnitAI>
-				</UnitAI>
-				<UnitAI>
 					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<NotUnitAIs/>
+			<NotUnitAIs>
+					<!-- custom: archer is not strong enough to be valuable as an attacker, much more efficient/valuable
+					to keep it as a defeender only instead-->
+					<UnitAI>
+						<UnitAIType>UNITAI_ATTACK</UnitAIType>
+						<bUnitAI>1</bUnitAI>
+				</UnitAI>
+			</NotUnitAIs>
 			<Builds/>
 			<ReligionSpreads/>
 			<CorporationSpreads/>
@@ -10862,15 +10929,18 @@
 			<FlankingStrikes/>
 			<UnitAIs>
 				<UnitAI>
-					<UnitAIType>UNITAI_ATTACK</UnitAIType>
-					<bUnitAI>1</bUnitAI>
-				</UnitAI>
-				<UnitAI>
 					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<NotUnitAIs/>
+			<NotUnitAIs>
+					<!-- custom: archer is not strong enough to be valuable as an attacker, much more efficient/valuable
+					to keep it as a defeender only instead-->
+					<UnitAI>
+						<UnitAIType>UNITAI_ATTACK</UnitAIType>
+						<bUnitAI>1</bUnitAI>
+				</UnitAI>
+			</NotUnitAIs>
 			<Builds/>
 			<ReligionSpreads/>
 			<CorporationSpreads/>
@@ -11042,15 +11112,18 @@
 			<FlankingStrikes/>
 			<UnitAIs>
 				<UnitAI>
-					<UnitAIType>UNITAI_ATTACK</UnitAIType>
-					<bUnitAI>1</bUnitAI>
-				</UnitAI>
-				<UnitAI>
 					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<NotUnitAIs/>
+			<NotUnitAIs>
+					<!-- custom: archer is not strong enough to be valuable as an attacker, much more efficient/valuable
+					to keep it as a defeender only instead-->
+					<UnitAI>
+						<UnitAIType>UNITAI_ATTACK</UnitAIType>
+						<bUnitAI>1</bUnitAI>
+				</UnitAI>
+			</NotUnitAIs>
 			<Builds/>
 			<ReligionSpreads/>
 			<CorporationSpreads/>
@@ -11222,15 +11295,18 @@
 			<FlankingStrikes/>
 			<UnitAIs>
 				<UnitAI>
-					<UnitAIType>UNITAI_ATTACK</UnitAIType>
-					<bUnitAI>1</bUnitAI>
-				</UnitAI>
-				<UnitAI>
 					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<NotUnitAIs/>
+			<NotUnitAIs>
+					<!-- custom: longbowmen is not strong enough to be valuable as an attacker, much more efficient/valuable
+					to keep it as a defeender only instead-->
+					<UnitAI>
+						<UnitAIType>UNITAI_ATTACK</UnitAIType>
+						<bUnitAI>1</bUnitAI>
+				</UnitAI>
+			</NotUnitAIs>
 			<Builds/>
 			<ReligionSpreads/>
 			<CorporationSpreads/>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -15915,6 +15915,7 @@
 				<UnitAI>
 					<UnitAIType>UNITAI_COUNTER</UnitAIType>
 					<bUnitAI>1</bUnitAI>
+				</UnitAI>
 				<UnitAI>
 					<UnitAIType>UNITAI_PILLAGE</UnitAIType>
 					<bUnitAI>1</bUnitAI>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -4269,7 +4269,12 @@
 			<Capture>NONE</Capture>
 			<Combat>UNITCOMBAT_MELEE</Combat>
 			<Domain>DOMAIN_LAND</Domain>
-			<DefaultUnitAI>UNITAI_ATTACK</DefaultUnitAI>
+			<!-- custom: make them default to defenders, they could be attackers but less likely maybe this way?
+			Purpose is to make sure they are more likely to be upgraded into stronger units rather than die too soon
+			before that. Warriors are also a bit weak on total strength to be that effective to value sacrificing them,
+			their city defense bonus also makes it slightly more lean towards defending instead maybe
+			, was UNITAI_ATTACK -->
+			<DefaultUnitAI>UNITAI_CITY_DEFENSE</DefaultUnitAI>
 			<Invisible>NONE</Invisible>
 			<SeeInvisible>NONE</SeeInvisible>
 			<Description>TXT_KEY_UNIT_WARRIOR</Description>
@@ -4326,17 +4331,21 @@
 			<UnitCombatDefenders/>
 			<FlankingStrikes/>
 			<UnitAIs>
+				<!-- custom: warriors are valuable as city defenders too-->
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_RESERVE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
 				<UnitAI>
 					<UnitAIType>UNITAI_ATTACK</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<NotUnitAIs>
-				<UnitAI>
-					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
-					<bUnitAI>1</bUnitAI>
-				</UnitAI>
-			</NotUnitAIs>
+			<NotUnitAIs/>
 			<Builds/>
 			<ReligionSpreads/>
 			<CorporationSpreads/>
@@ -4449,7 +4458,12 @@
 			<Capture>NONE</Capture>
 			<Combat>UNITCOMBAT_MELEE</Combat>
 			<Domain>DOMAIN_LAND</Domain>
-			<DefaultUnitAI>UNITAI_ATTACK</DefaultUnitAI>
+			<!-- custom: make them default to defenders, they could be attackers but less likely maybe this way?
+			Purpose is to make sure they are more likely to be upgraded into stronger units rather than die too soon
+			before that. Warriors are also a bit weak on total strength to be that effective to value sacrificing them,
+			their city defense bonus also makes it slightly more lean towards defending instead maybe
+			, was UNITAI_ATTACK -->
+			<DefaultUnitAI>UNITAI_CITY_DEFENSE</DefaultUnitAI>
 			<Invisible>NONE</Invisible>
 			<SeeInvisible>NONE</SeeInvisible>
 			<Description>TXT_KEY_UNIT_INCAN_QUECHUA</Description>
@@ -4515,13 +4529,17 @@
 					<UnitAIType>UNITAI_ATTACK</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
-			</UnitAIs>
-			<NotUnitAIs>
+				<!-- custom: warriors are valuable as city defenders too-->
 				<UnitAI>
 					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
-			</NotUnitAIs>
+				<UnitAI>
+					<UnitAIType>UNITAI_RESERVE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+			</UnitAIs>
+			<NotUnitAIs/>
 			<Builds/>
 			<ReligionSpreads/>
 			<CorporationSpreads/>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -6893,11 +6893,19 @@
 			<FlankingStrikes/>
 			<UnitAIs>
 				<UnitAI>
-					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
+					<UnitAIType>UNITAI_RESERVE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
-			</UnitAIs>---------------------------------------
-			</NotUnitAIs />
+				<UnitAI>
+					<UnitAIType>UNITAI_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+			</UnitAIs>
+			<NotUnitAIs/>
 			<Builds/>
 			<ReligionSpreads/>
 			<CorporationSpreads/>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -7501,7 +7501,7 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 				<UnitAI>
-					<UnitAIType>UNITAI_CITY_ATTACK</UnitAIType>
+					<UnitAIType>UNITAI_ATTACK_CITY</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 				<UnitAI>
@@ -7718,7 +7718,7 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 				<UnitAI>
-					<UnitAIType>UNITAI_CITY_ATTACK</UnitAIType>
+					<UnitAIType>UNITAI_ATTACK_CITY</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 				<UnitAI>
@@ -10778,7 +10778,7 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 				<UnitAI>
-					<UnitAIType>UNITAI_CITY_ATTACK</UnitAIType>
+					<UnitAIType>UNITAI_ATTACK_CITY</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 				<UnitAI>
@@ -10989,7 +10989,7 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 				<UnitAI>
-					<UnitAIType>UNITAI_CITY_ATTACK</UnitAIType>
+					<UnitAIType>UNITAI_ATTACK_CITY</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 				<UnitAI>
@@ -11201,7 +11201,7 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 				<UnitAI>
-					<UnitAIType>UNITAI_CITY_ATTACK</UnitAIType>
+					<UnitAIType>UNITAI_ATTACK_CITY</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 				<UnitAI>
@@ -11413,7 +11413,7 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 				<UnitAI>
-					<UnitAIType>UNITAI_CITY_ATTACK</UnitAIType>
+					<UnitAIType>UNITAI_ATTACK_CITY</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 				<UnitAI>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -15692,13 +15692,13 @@
 					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
-				<!-- custom: tentative chance to avoid catapults suicides/getting baited during enemy invasion -->
+				<!-- custom: tentative change to avoid catapults suicides/getting baited during enemy invasion -->
 				<UnitAI>
 					<UnitAIType>UNITAI_RESERVE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<!-- custom: tentative chance to avoid catapults suicides/getting baited during enemy invasion -->
+			<!-- custom: tentative change to avoid catapults suicides/getting baited during enemy invasion -->
 			<NotUnitAIs>
 				<UnitAI>
 					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
@@ -15711,6 +15711,7 @@
 				<UnitAI>
 					<UnitAIType>UNITAI_COUNTER</UnitAIType>
 					<bUnitAI>1</bUnitAI>
+				</UnitAI>
 				<UnitAI>
 					<UnitAIType>UNITAI_PILLAGE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
@@ -15895,13 +15896,13 @@
 					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
-				<!-- custom: tentative chance to avoid catapults suicides/getting baited during enemy invasion -->
+				<!-- custom: tentative change to avoid catapults suicides/getting baited during enemy invasion -->
 				<UnitAI>
 					<UnitAIType>UNITAI_RESERVE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<!-- custom: tentative chance to avoid catapults suicides/getting baited during enemy invasion -->
+			<!-- custom: tentative change to avoid catapults suicides/getting baited during enemy invasion -->
 			<NotUnitAIs>
 				<UnitAI>
 					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
@@ -16099,7 +16100,7 @@
 					<UnitAIType>UNITAI_ATTACK_CITY</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
-				<!-- custom: tentative chance to avoid trebuchets suicides/getting baited during enemy invasion -->
+				<!-- custom: tentative change to avoid trebuchets suicides/getting baited during enemy invasion -->
 				<UnitAI>
 					<UnitAIType>UNITAI_RESERVE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
@@ -16114,10 +16115,11 @@
 					<UnitAIType>UNITAI_ATTACK</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
-				<!-- custom: tentative chance to avoid trebuchets suicides/getting baited during enemy invasion -->
+				<!-- custom: tentative change to avoid trebuchets suicides/getting baited during enemy invasion -->
 				<UnitAI>
 					<UnitAIType>UNITAI_COUNTER</UnitAIType>
 					<bUnitAI>1</bUnitAI>
+				</UnitAI>
 				<UnitAI>
 					<UnitAIType>UNITAI_PILLAGE</UnitAIType>
 					<bUnitAI>1</bUnitAI>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -7469,15 +7469,15 @@
 					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_RESERVE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
 			</UnitAIs>
 			<!-- custom: value pikemen more as city defenders, also the rock paper scissors logic when attacking a unit a group
 			makes it more likely that the pikeman would be wasted (or not used as optimally) while attacking a unit it is less good
 			against rather than defending (especially defending cities) against units it is very good against-->
 			<NotUnitAIs>
-				<UnitAI>
-					<UnitAIType>UNITAI_RESERVE</UnitAIType>
-					<bUnitAI>1</bUnitAI>
-				</UnitAI>
 				<UnitAI>
 					<UnitAIType>UNITAI_COUNTER</UnitAIType>
 					<bUnitAI>1</bUnitAI>
@@ -7681,29 +7681,13 @@
 			<UnitCombatDefenders/>
 			<FlankingStrikes/>
 			<!-- custom: make pikemen more strictly defenders, to increase military effectiveness at the cost of versatility -->
-			<!-- <UnitAIs> -->
-				<!-- K-Mod -->
-				<!--<UnitAI>
-					<UnitAIType>UNITAI_ATTACK</UnitAIType>
+			<UnitAIs>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 				<UnitAI>
 					<UnitAIType>UNITAI_RESERVE</UnitAIType>
-					<bUnitAI>1</bUnitAI>
-				</UnitAI>
-				<UnitAI>
-					<UnitAIType>UNITAI_COUNTER</UnitAIType>
-					<bUnitAI>1</bUnitAI>
-				</UnitAI>
-				<UnitAI>
-					<UnitAIType>UNITAI_CITY_COUNTER</UnitAIType>
-					<bUnitAI>1</bUnitAI>
-				</UnitAI>
-			</UnitAIs>
-			<NotUnitAIs/>-->
-			<UnitAIs>
-				<UnitAI>
-					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
@@ -7711,10 +7695,6 @@
 			makes it more likely that the pikeman would be wasted (or not used as optimally) while attacking a unit it is less good
 			against rather than defending (especially defending cities) against units it is very good against-->
 			<NotUnitAIs>
-				<UnitAI>
-					<UnitAIType>UNITAI_RESERVE</UnitAIType>
-					<bUnitAI>1</bUnitAI>
-				</UnitAI>
 				<UnitAI>
 					<UnitAIType>UNITAI_COUNTER</UnitAIType>
 					<bUnitAI>1</bUnitAI>
@@ -10768,13 +10748,42 @@
 					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
+				<!-- custom: if AI is strong enough to start an offensive on someone, it may not hurt to take a few defenders
+				as an extra to do so. If these defenders die then AI could build offensive units maybe now instead.
+				They may also help defend other cities by roaming -->
+				<UnitAI>
+					<UnitAIType>UNITAI_RESERVE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
 			</UnitAIs>
 			<NotUnitAIs>
-					<!-- custom: archer is not strong enough to be valuable as an attacker, much more efficient/valuable
-					to keep it as a defeender only instead-->
-					<UnitAI>
+				<!-- custom: archer is not strong enough to be valuable as an attacker, much more efficient/valuable
+				to keep it as a defeender only instead-->
+				<UnitAI>
 						<UnitAIType>UNITAI_ATTACK</UnitAIType>
 						<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<!-- custom: make extra sure these defender type units are not baited or suicide during enemy invasion
+				or other related situations -->
+				<UnitAI>
+					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_PILLAGE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</NotUnitAIs>
 			<Builds/>
@@ -10950,13 +10959,42 @@
 					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
+				<!-- custom: if AI is strong enough to start an offensive on someone, it may not hurt to take a few defenders
+				as an extra to do so. If these defenders die then AI could build offensive units maybe now instead.
+				They may also help defend other cities by roaming -->
+				<UnitAI>
+					<UnitAIType>UNITAI_RESERVE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
 			</UnitAIs>
 			<NotUnitAIs>
-					<!-- custom: archer is not strong enough to be valuable as an attacker, much more efficient/valuable
-					to keep it as a defeender only instead-->
-					<UnitAI>
-						<UnitAIType>UNITAI_ATTACK</UnitAIType>
-						<bUnitAI>1</bUnitAI>
+				<!-- custom: archer is not strong enough to be valuable as an attacker, much more efficient/valuable
+				to keep it as a defeender only instead-->
+				<UnitAI>
+					<UnitAIType>UNITAI_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<!-- custom: make extra sure these defender type units are not baited or suicide during enemy invasion
+				or other related situations -->
+				<UnitAI>
+					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_PILLAGE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</NotUnitAIs>
 			<Builds/>
@@ -11133,13 +11171,42 @@
 					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
+				<!-- custom: if AI is strong enough to start an offensive on someone, it may not hurt to take a few defenders
+				as an extra to do so. If these defenders die then AI could build offensive units maybe now instead.
+				They may also help defend other cities by roaming -->
+				<UnitAI>
+					<UnitAIType>UNITAI_RESERVE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
 			</UnitAIs>
 			<NotUnitAIs>
-					<!-- custom: archer is not strong enough to be valuable as an attacker, much more efficient/valuable
-					to keep it as a defeender only instead-->
-					<UnitAI>
-						<UnitAIType>UNITAI_ATTACK</UnitAIType>
-						<bUnitAI>1</bUnitAI>
+				<!-- custom: archer is not strong enough to be valuable as an attacker, much more efficient/valuable
+				to keep it as a defeender only instead-->
+				<UnitAI>
+					<UnitAIType>UNITAI_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<!-- custom: make extra sure these defender type units are not baited or suicide during enemy invasion
+				or other related situations -->
+				<UnitAI>
+					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_PILLAGE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</NotUnitAIs>
 			<Builds/>
@@ -11316,13 +11383,42 @@
 					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
+				<!-- custom: if AI is strong enough to start an offensive on someone, it may not hurt to take a few defenders
+				as an extra to do so. If these defenders die then AI could build offensive units maybe now instead.
+				They may also help defend other cities by roaming -->
+				<UnitAI>
+					<UnitAIType>UNITAI_RESERVE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
 			</UnitAIs>
 			<NotUnitAIs>
-					<!-- custom: longbowmen is not strong enough to be valuable as an attacker, much more efficient/valuable
-					to keep it as a defeender only instead-->
-					<UnitAI>
-						<UnitAIType>UNITAI_ATTACK</UnitAIType>
-						<bUnitAI>1</bUnitAI>
+				<!-- custom: longbowmen are not strong enough to be valuable as an attacker, much more efficient/valuable
+				to keep them as a defeender only instead-->
+				<UnitAI>
+					<UnitAIType>UNITAI_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<!-- custom: make extra sure these defender type units are not baited or suicide during enemy invasion
+				or other related situations -->
+				<UnitAI>
+					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_PILLAGE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</NotUnitAIs>
 			<Builds/>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -15588,8 +15588,30 @@
 					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
+				<!-- custom: tentative chance to avoid catapults suicides/getting baited during enemy invasion -->
+				<UnitAI>
+					<UnitAIType>UNITAI_RESERVE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
 			</UnitAIs>
-			<NotUnitAIs/>
+			<!-- custom: tentative chance to avoid catapults suicides/getting baited during enemy invasion -->
+			<NotUnitAIs>
+				<UnitAI>
+					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_PILLAGE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+			</NotUnitAIs>
 			<Builds/>
 			<ReligionSpreads/>
 			<CorporationSpreads/>
@@ -15769,12 +15791,30 @@
 					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
+				<!-- custom: tentative chance to avoid catapults suicides/getting baited during enemy invasion -->
 				<UnitAI>
-					<UnitAIType>UNITAI_COUNTER</UnitAIType>
+					<UnitAIType>UNITAI_RESERVE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<NotUnitAIs/>
+			<!-- custom: tentative chance to avoid catapults suicides/getting baited during enemy invasion -->
+			<NotUnitAIs>
+				<UnitAI>
+					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_PILLAGE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+			</NotUnitAIs>
 			<Builds/>
 			<ReligionSpreads/>
 			<CorporationSpreads/>
@@ -15955,6 +15995,11 @@
 					<UnitAIType>UNITAI_ATTACK_CITY</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
+				<!-- custom: tentative chance to avoid trebuchets suicides/getting baited during enemy invasion -->
+				<UnitAI>
+					<UnitAIType>UNITAI_RESERVE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
 			</UnitAIs>
 			<NotUnitAIs>
 				<UnitAI>
@@ -15963,6 +16008,14 @@
 				</UnitAI>
 				<UnitAI>
 					<UnitAIType>UNITAI_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<!-- custom: tentative chance to avoid trebuchets suicides/getting baited during enemy invasion -->
+				<UnitAI>
+					<UnitAIType>UNITAI_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_PILLAGE</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</NotUnitAIs>


### PR DESCRIPTION
A batch of changes that go quite well together maybe.

A key focus was to make AI less often blunder its (more suited as) defender-type units.
Also, building archers less in favour of warriors early may allow for an earlier/faster expansion for the AI

Reworked the early free techs so that they focus more on early growth even if tech cost is less than with the replaced techs.
Increased slightly at mid-high difficulties the tech cost for the human player (that may have been a bit too low), and even more slightly reduced them at highest difficulties to accomodate that change.

Also in general, early and growth type techs are valued more now by the AI, at least in theory (would need to test to be sure of how the AI behaves).
