### PR TITLE
Unit promotions changes (woodsman, guerilla, barrage), rework of the explorer and the scout

### DIFF
--- a/Assets/XML/Units/CIV4PromotionInfos.xml
+++ b/Assets/XML/Units/CIV4PromotionInfos.xml
@@ -1569,7 +1569,8 @@
 			<iCityAttack>0</iCityAttack>
 			<iCityDefense>0</iCityDefense>
 			<iHillsAttack>0</iHillsAttack>
-			<iHillsDefense>20</iHillsDefense>
+			<!-- custom: similarly to woodsman promotions, make it more even between levels, was 20 -->
+			<iHillsDefense>25</iHillsDefense>
 			<iKamikazePercent>0</iKamikazePercent>
 			<iRevoltProtection>0</iRevoltProtection>
 			<iCollateralDamageProtection>0</iCollateralDamageProtection>
@@ -1644,7 +1645,8 @@
 			<iCityAttack>0</iCityAttack>
 			<iCityDefense>0</iCityDefense>
 			<iHillsAttack>0</iHillsAttack>
-			<iHillsDefense>30</iHillsDefense>
+			<!-- custom: similarly to woodsman promotions, make it more even between levels, was 30 -->
+			<iHillsDefense>25</iHillsDefense>
 			<iKamikazePercent>0</iKamikazePercent>
 			<iRevoltProtection>0</iRevoltProtection>
 			<iCollateralDamageProtection>0</iCollateralDamageProtection>

--- a/Assets/XML/Units/CIV4PromotionInfos.xml
+++ b/Assets/XML/Units/CIV4PromotionInfos.xml
@@ -2334,7 +2334,13 @@
 			<iAdjacentTileHealChange>0</iAdjacentTileHealChange>
 			<iCombatPercent>0</iCombatPercent>
 			<iCityAttack>0</iCityAttack>
-			<iCityDefense>20</iCityDefense>
+			<!-- custom: make this promotion gradual too, also as strong as an option as guerilla
+			promotions with their change now, was 20. It could be also said perhaps that cities are
+			easier to garrison than to attack, especially at earlier/lower levels (anyone could maybe
+			defend the city or barricade, but fewer would be able to attack maybe.
+			This also makes defender units slightly more attractive as only them can have this
+			promotion unless i'm mistaken) -->
+			<iCityDefense>25</iCityDefense>
 			<iHillsAttack>0</iHillsAttack>
 			<iHillsDefense>0</iHillsDefense>
 			<iKamikazePercent>0</iKamikazePercent>
@@ -2476,7 +2482,9 @@
 			<iAdjacentTileHealChange>0</iAdjacentTileHealChange>
 			<iCombatPercent>0</iCombatPercent>
 			<iCityAttack>0</iCityAttack>
-			<iCityDefense>30</iCityDefense>
+			<!-- custom: make this promotion gradual in line with the other city garrison
+			ones, was 30 -->
+			<iCityDefense>25</iCityDefense>
 			<iHillsAttack>0</iHillsAttack>
 			<iHillsDefense>0</iHillsDefense>
 			<iKamikazePercent>0</iKamikazePercent>
@@ -2981,7 +2989,13 @@
 			<iEvasionChange>0</iEvasionChange>
 			<iWithdrawalChange>0</iWithdrawalChange>
 			<iCargoChange>0</iCargoChange>
-			<iCollateralDamageChange>30</iCollateralDamageChange>
+			<!-- custom: making this more gradual, also considering siege units are
+			very strong and good at decimating stacks (on top of bombarding cities),
+			and also considering that barrage promotion is more versatile than city
+			attack promotion (that could only be used to attack cities, not random
+			stacks or units elsewhere), i am nerfing this a bit. 20% applied to many
+			units should/may still be quite good., was 30 -->
+			<iCollateralDamageChange>20</iCollateralDamageChange>
 			<iBombardRateChange>0</iBombardRateChange>
 			<iFirstStrikesChange>0</iFirstStrikesChange>
 			<iChanceFirstStrikesChange>0</iChanceFirstStrikesChange>
@@ -3057,7 +3071,10 @@
 			<iEvasionChange>0</iEvasionChange>
 			<iWithdrawalChange>0</iWithdrawalChange>
 			<iCargoChange>0</iCargoChange>
-			<iCollateralDamageChange>50</iCollateralDamageChange>
+			<!-- custom: making this more gradual, and nerfing this more severely
+			than barrage 2, maybe this way this option is as competitive as city
+			attack 3?, was 50 -->
+			<iCollateralDamageChange>20</iCollateralDamageChange>
 			<iBombardRateChange>0</iBombardRateChange>
 			<iFirstStrikesChange>0</iFirstStrikesChange>
 			<iChanceFirstStrikesChange>0</iChanceFirstStrikesChange>

--- a/Assets/XML/Units/CIV4PromotionInfos.xml
+++ b/Assets/XML/Units/CIV4PromotionInfos.xml
@@ -1807,15 +1807,31 @@
 			<iExperiencePercent>0</iExperiencePercent>
 			<TerrainAttacks/>
 			<TerrainDefenses/>
-			<FeatureAttacks/>
+			<!-- custom: give woodsman promotion same attack bonuses than jungle bonuses it has,
+		    no specific reason why units would be good at defense in forest/jungle but weirdly not as good
+			at offense in such terrains
+			may also buff the woodsman promotion which is quite a bit weaker than other promotions, and since
+			city inner tile is never a forest or a jungle tile after city is planted, the woodsman promotion
+			would still not affect too much the warfare in the end so it would not be OP.
+			Also tweak the values a bit for it to be more gradual, was 20 -->
+			<FeatureAttacks>
+				<FeatureAttack>
+					<FeatureType>FEATURE_JUNGLE</FeatureType>
+					<iFeatureAttack>25</iFeatureAttack>
+				</FeatureAttack>
+				<FeatureAttack>
+					<FeatureType>FEATURE_FOREST</FeatureType>
+					<iFeatureAttack>25</iFeatureAttack>
+				</FeatureAttack>
+			</FeatureAttacks>
 			<FeatureDefenses>
 				<FeatureDefense>
 					<FeatureType>FEATURE_JUNGLE</FeatureType>
-					<iFeatureDefense>20</iFeatureDefense>
+					<iFeatureDefense>25</iFeatureDefense>
 				</FeatureDefense>
 				<FeatureDefense>
 					<FeatureType>FEATURE_FOREST</FeatureType>
-					<iFeatureDefense>20</iFeatureDefense>
+					<iFeatureDefense>25</iFeatureDefense>
 				</FeatureDefense>
 			</FeatureDefenses>
 			<UnitCombatMods/>
@@ -1891,15 +1907,31 @@
 			<iExperiencePercent>0</iExperiencePercent>
 			<TerrainAttacks/>
 			<TerrainDefenses/>
-			<FeatureAttacks/>
+			<!-- custom: give woodsman promotion same attack bonuses than jungle bonuses it has,
+		    no specific reason why units would be good at defense in forest/jungle but weirdly not as good
+			at offense in such terrains
+			may also buff the woodsman promotion which is quite a bit weaker than other promotions, and since
+			city inner tile is never a forest or a jungle tile after city is planted, the woodsman promotion
+			would still not affect too much the warfare in the end so it would not be OP.
+			Also tweak the values a bit for it to be more gradual, was 30 -->
+			<FeatureAttacks>
+				<FeatureAttack>
+					<FeatureType>FEATURE_JUNGLE</FeatureType>
+					<iFeatureAttack>25</iFeatureAttack>
+				</FeatureAttack>
+				<FeatureAttack>
+					<FeatureType>FEATURE_FOREST</FeatureType>
+					<iFeatureAttack>25</iFeatureAttack>
+				</FeatureAttack>
+			</FeatureAttacks>
 			<FeatureDefenses>
 				<FeatureDefense>
 					<FeatureType>FEATURE_JUNGLE</FeatureType>
-					<iFeatureDefense>30</iFeatureDefense>
+					<iFeatureDefense>25</iFeatureDefense>
 				</FeatureDefense>
 				<FeatureDefense>
 					<FeatureType>FEATURE_FOREST</FeatureType>
-					<iFeatureDefense>30</iFeatureDefense>
+					<iFeatureDefense>25</iFeatureDefense>
 				</FeatureDefense>
 			</FeatureDefenses>
 			<UnitCombatMods/>
@@ -1984,17 +2016,34 @@
 			<iExperiencePercent>0</iExperiencePercent>
 			<TerrainAttacks/>
 			<TerrainDefenses/>
+			<!-- custom: give woodsman promotion same attack bonuses than jungle bonuses it has,
+		    no specific reason why units would be good at defense in forest/jungle but weirdly not as good
+			at offense in such terrains
+			may also buff the woodsman promotion which is quite a bit weaker than other promotions, and since
+			city inner tile is never a forest or a jungle tile after city is planted, the woodsman promotion
+			would still not affect too much the warfare in the end so it would not be OP.
+			Also tweak the values a bit for it to be more gradual, was 50 -->
 			<FeatureAttacks>
 				<FeatureAttack>
 					<FeatureType>FEATURE_JUNGLE</FeatureType>
-					<iFeatureAttack>50</iFeatureAttack>
+					<iFeatureAttack>25</iFeatureAttack>
 				</FeatureAttack>
 				<FeatureAttack>
 					<FeatureType>FEATURE_FOREST</FeatureType>
-					<iFeatureAttack>50</iFeatureAttack>
+					<iFeatureAttack>25</iFeatureAttack>
 				</FeatureAttack>
 			</FeatureAttacks>
-			<FeatureDefenses/>
+			<!-- custom: was 0 -->
+			<FeatureDefenses>
+				<FeatureDefense>
+					<FeatureType>FEATURE_JUNGLE</FeatureType>
+					<iFeatureDefense>25</iFeatureDefense>
+				</FeatureDefense>
+				<FeatureDefense>
+					<FeatureType>FEATURE_FOREST</FeatureType>
+					<iFeatureDefense>25</iFeatureDefense>
+				</FeatureDefense>
+			</FeatureDefenses>
 			<UnitCombatMods/>
 			<DomainMods/>
 			<TerrainDoubleMoves/>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -1414,7 +1414,16 @@
 			<!-- advc.315a: Replaced with OnlyAttackAnimals -->
 			<bOnlyDefensive>0</bOnlyDefensive>
 			<!-- advc.315a -->
-			<bOnlyAttackAnimals>1</bOnlyAttackAnimals>
+			<!-- custom: minor rework, allow the scout to attack all rivals and cities or defend them,
+			but it should be disincentivized enough for human players due its low strength and not much
+			bonuses especially in city attack-defense, but it is better than nothing and quite realistic
+			that they would stand as last defenders, so adding it. The human player may also find some
+			other uses, that should not be mostly about gaining a strong advantage at war, for these units,
+			so maybe worth adding too.
+			For AI players, tags were added to more strictly enforce that they are used as explore units
+			only and nothing else ideally.
+			-->
+			<bOnlyAttackAnimals>0</bOnlyAttackAnimals>
 			<!-- advc.315b -->
 			<bOnlyAttackBarbarians>0</bOnlyAttackBarbarians>
 			<bNoCapture>0</bNoCapture>
@@ -1464,7 +1473,49 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<NotUnitAIs/>
+			<!-- custom: similarly as in the explorer rework, adding some AI player tags to make
+			extra sure scouts are not used/confused by the AI as attackers or even defenders.
+			The human player may do as they wish (for example baiting/defending against animals or
+			something), it should not be too valuable use of the scout, but maybe in some cases this
+			could make a difference, so allowing it (see above the scout rework changes) -->
+			<NotUnitAIs>
+				<UnitAI>
+					<UnitAIType>UNITAI_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_ATTACK_CITY</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_SPECIAL</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_PILLAGE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_RESERVE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+			</NotUnitAIs>
 			<Builds/>
 			<ReligionSpreads/>
 			<CorporationSpreads/>
@@ -1524,8 +1575,20 @@
 			<iCityAttack>0</iCityAttack>
 			<iCityDefense>0</iCityDefense>
 			<!-- advc.315c: Was 100; now BarbarianCombat instead. -->
-			<iAnimalCombat>0</iAnimalCombat>
-			<iBarbarianCombat>100</iBarbarianCombat>
+			<!-- custom: scout rework. Make scouts especially good against animals
+			(it is a sort of hunting after all), not so much against other humans
+			even if they are barbarians, was 0 -->
+			<!-- custom: i could have kept the animal bonus to 100 (so that 100 + 25 = 125
+			against animals), but that would be a bit too strong (and perhaps stronger
+			than needed especially considering the unit's cost. But if someday someone
+			would want to create animal units for other rivals, then they could maybe
+			decrease this to 75 (so that 100 + 25 = 125% against barbarian animals,
+			and 100% against other animals. Seems a bit too complicated and unlikely to
+			happen soon, so to simplify this i chose 75 instead of 100., was 0. -->
+			<iAnimalCombat>75</iAnimalCombat>
+			<!-- custom: was 100, scouts should not have good odds against anything other
+			than a warrior, even a barbarian warrior should still be stronger than a scout -->
+			<iBarbarianCombat>25</iBarbarianCombat>
 			<iHillsAttack>0</iHillsAttack>
 			<iHillsDefense>0</iHillsDefense>
 			<TerrainNatives/>
@@ -1771,7 +1834,32 @@
 			<iCollateralDamageMaxUnits>0</iCollateralDamageMaxUnits>
 			<iCityAttack>0</iCityAttack>
 			<iCityDefense>0</iCityDefense>
-			<iAnimalCombat>0</iAnimalCombat>
+			<!-- custom: should not be weaker than the scout in that regard, even if there
+			should be no animals left at this stage of the game -->
+			<!-- custom: as in the scout rework, make explorers especially good against animals
+			(it is a sort of hunting after all), not so much against other humans even if
+			they are barbarians, was 0 -->
+			<!-- custom: i could have kept the animal bonus to 100 (so that 100 + 25 = 125
+			against animals), but that would be a bit too strong (and perhaps stronger
+			than needed especially considering the unit's cost. But if someday someone
+			would want to create animal units for other rivals, then they could maybe
+			decrease this to 75 (so that 100 + 25 = 125% against barbarian animals,
+			and 100% against other animals. Seems a bit too complicated and unlikely to
+			happen soon, so to simplify this i chose 75 instead of 100., was 0. -->
+			<iAnimalCombat>75</iAnimalCombat>
+			<!-- custom tag: missing tag for some reason, i don't know if it breaks something to
+			add it, would need to test to see, but ideally no reason it should be worse than the
+			scout against barbarians, even if the boost is small -->
+			<!-- custom: this is mostly for role playing if i may say or-and historical accuracy
+			/realism, as there should be mostly no barbarians left when players start to have explorers
+			available, but if there were, the explorer would not be stronger than regular military
+			units to take the barbarians down, but they should be about strong enough to do so
+			(still slightly weaker and limited to vs barbarian fights), but more likely to happen
+			now if the player wishes so (mostly human players as this is currently more discouraged
+			for AI players in this mod to improve their efficiency). It also makes sense that their
+			tactics are slightly better against barbarians than those of the scouts, even if not by a
+			lot so i increased it from 25 that i chose initially to 50 -->
+			<iBarbarianCombat>50</iBarbarianCombat>
 			<iHillsAttack>0</iHillsAttack>
 			<iHillsDefense>0</iHillsDefense>
 			<TerrainNatives/>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -1578,6 +1578,15 @@
 					<PromotionType>PROMOTION_WOODSMAN1</PromotionType>
 					<bFreePromotion>1</bFreePromotion>
 				</FreePromotion>
+				<!-- custom: similarly as in the explorer rework, also give flaking 1 (only) to
+				scouts, should be valuable and also realistic. Exploring should involve to some
+				extent (i think) being good at retreating too. Since these units cannot become
+				military strong units, it's most likely (i think) fine to give them such bonuses
+				-->
+				<FreePromotion>
+					<PromotionType>PROMOTION_FLANKING1</PromotionType>
+					<bFreePromotion>1</bFreePromotion>
+				</FreePromotion>
 			</FreePromotions>
 			<LeaderPromotion>NONE</LeaderPromotion>
 			<iLeaderExperience>0</iLeaderExperience>
@@ -1605,9 +1614,17 @@
 			<!-- advc.315a -->
 			<bOnlyAttackAnimals>0</bOnlyAttackAnimals>
 			<!-- advc.315b -->
-			<bOnlyAttackBarbarians>1</bOnlyAttackBarbarians>
+			<!-- custom: unit reworked, can attack other players (more realistic), but should have
+			little incentive to do so considering its now low strength. More likely to be useful and valuable
+			for human players as a scouting unit. For AIs i added changes to make extra sure they use it strictly
+			(as much as possible) as an explorer and not for warfare, was 1-->
+			<bOnlyAttackBarbarians>0</bOnlyAttackBarbarians>
 			<!-- advc.315b: Not supposed to conquer Barbarian cities -->
-			<bNoCapture>1</bNoCapture>
+			<!-- custom: can conquer cities but should have little incentive to do so due to its low strength,
+			but if it were to actually conquer a city, especially barbarian city, it may be realistic and also
+			making sense too maybe, as it could only do so against really low strength defenders after its rework,
+			was 1 -->
+			<bNoCapture>0</bNoCapture>
 			<bQuickCombat>0</bQuickCombat>
 			<bRivalTerritory>0</bRivalTerritory>
 			<bMilitaryHappiness>0</bMilitaryHappiness>
@@ -1650,7 +1667,50 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<NotUnitAIs/>
+			<!-- custom: unit reworked, can attack cities if the human player wishes to do so,
+			but due to its low strength now it should be strongly disincentivized for human players.
+			Opportunistically maybe against really weak defenders at best maybe. But it should be
+			valuable as a scouting unit for the human player.
+			For AI players, similarly as for archer-type units, adding some NotUnitAIs to make
+			extra sure they are not used/confused by the AI as attackers or even defenders-->
+			<NotUnitAIs>
+				<UnitAI>
+					<UnitAIType>UNITAI_ATTACK</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_ATTACK_CITY</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_COLLATERAL</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_COUNTER</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_DEFENSE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_CITY_SPECIAL</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_PILLAGE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+				<UnitAI>
+					<UnitAIType>UNITAI_RESERVE</UnitAIType>
+					<bUnitAI>1</bUnitAI>
+				</UnitAI>
+			</NotUnitAIs>
 			<Builds/>
 			<ReligionSpreads/>
 			<CorporationSpreads/>
@@ -1669,7 +1729,8 @@
 			<ProductionTraits/>
 			<Flavors/>
 			<iAIWeight>0</iAIWeight>
-			<iCost>40</iCost>
+			<!-- custom: unit reworked, was 40 -->
+			<iCost>30</iCost>
 			<iHurryCostModifier>0</iHurryCostModifier>
 			<iAdvancedStartCost>100</iAdvancedStartCost>
 			<iAdvancedStartCostIncrease>0</iAdvancedStartCostIncrease>
@@ -1693,7 +1754,8 @@
 			<FeatureImpassables/>
 			<TerrainPassableTechs/>
 			<FeaturePassableTechs/>
-			<iCombat>4</iCombat>
+			<!-- custom: unit reworked, was 4 -->
+			<iCombat>2</iCombat>
 			<iCombatLimit>100</iCombatLimit>
 			<iAirCombat>0</iAirCombat>
 			<iAirCombatLimit>0</iAirCombatLimit>
@@ -1756,12 +1818,31 @@
 			<!-- custom: unlike what is said in advc.315c, i think explore units should be good
 			at exploring, navigating forest type terrains is a good way to do so. It may be more
 			realistic and immersive this way. The verbose should not be a problem too.
-			There should be better ways to rework the unit maybe than to remove some of its
-			charateristic abilities, so for now i am reenabling woodsman 1 free promotion,
+			The unit is reworked now so having this bonus should not hurt, it increases immersion
+			too i think.
 			was empty -->
 			<FreePromotions>
 				<FreePromotion>
 					<PromotionType>PROMOTION_WOODSMAN1</PromotionType>
+					<bFreePromotion>1</bFreePromotion>
+				</FreePromotion>
+				<!-- custom: since woodsman promotion does not help to conquer cities, it is probably
+				fine (and realistic to give it to explorers, they are more in control of forest-jungle
+				environments, but still not enough to threaten specialized military units) -->
+				<FreePromotion>
+					<PromotionType>PROMOTION_WOODSMAN2</PromotionType>
+					<bFreePromotion>1</bFreePromotion>
+				</FreePromotion>
+			<!-- custom: on top of that, giving them double flanking promotions, which should make them
+			very valuable as explorer-scouting units, especially considering they have no road obstruction.
+			Note: now that many AIs often get Compass as a free tech, perhaps it makes this tech more
+			valuable too now -->
+				<FreePromotion>
+					<PromotionType>PROMOTION_FLANKING1</PromotionType>
+					<bFreePromotion>1</bFreePromotion>
+				</FreePromotion>
+				<FreePromotion>
+					<PromotionType>PROMOTION_FLANKING2</PromotionType>
 					<bFreePromotion>1</bFreePromotion>
 				</FreePromotion>
 			</FreePromotions>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -1567,7 +1567,18 @@
 			<bShiftDown>0</bShiftDown>
 			<bCtrlDown>0</bCtrlDown>
 			<iHotKeyPriority>0</iHotKeyPriority>
-			<FreePromotions/>
+			<!-- custom: similarly to what i did for the explorer unit, i think explore units
+			should be good at exploring, navigating forest type terrains is a good way to do so.
+			It is also a way to make the woodsman promotion play more of a key role in the game,
+			as it is currently quite useless i think. Scouts being good at such "terrains" (forest
+			-jungle, that civ4 code seems to name features) may be more realistic and immersive
+			this way, was empty -->
+			<FreePromotions>
+				<FreePromotion>
+					<PromotionType>PROMOTION_WOODSMAN1</PromotionType>
+					<bFreePromotion>1</bFreePromotion>
+				</FreePromotion>
+			</FreePromotions>
 			<LeaderPromotion>NONE</LeaderPromotion>
 			<iLeaderExperience>0</iLeaderExperience>
 		</UnitInfo>
@@ -1742,7 +1753,18 @@
 			<bCtrlDown>0</bCtrlDown>
 			<iHotKeyPriority>0</iHotKeyPriority>
 			<!-- advc.315c: was PROMOTION_GUERILLA1 and PROMOTION_WOODSMAN1 -->
-			<FreePromotions/>
+			<!-- custom: unlike what is said in advc.315c, i think explore units should be good
+			at exploring, navigating forest type terrains is a good way to do so. It may be more
+			realistic and immersive this way. The verbose should not be a problem too.
+			There should be better ways to rework the unit maybe than to remove some of its
+			charateristic abilities, so for now i am reenabling woodsman 1 free promotion,
+			was empty -->
+			<FreePromotions>
+				<FreePromotion>
+					<PromotionType>PROMOTION_WOODSMAN1</PromotionType>
+					<bFreePromotion>1</bFreePromotion>
+				</FreePromotion>
+			</FreePromotions>
 			<LeaderPromotion>NONE</LeaderPromotion>
 			<iLeaderExperience>0</iLeaderExperience>
 		</UnitInfo>


### PR DESCRIPTION
See commit log for the details of the changes.

Mainly, about promotions, making each promotion a more valuable option to consider, buffed a few promotions, changed a few, nerfed a few:
buffed: woodsman (same attack bonuses as defense bonuses, maybe it helps the AI and this promotion to be more valuable without being OP i think, in particular due to not being helpful in city attacks or defenses.
changed: guerilla,
nerfed: barrage (siege are a bit too op i think, now barrage that is more versatile should be about as valuable as city raider that is more specialized so deserves to be a bit stronger in exchange i think

Reworked the explorer and scout units, should be hopefully much more immersive and maybe worthwhile/versatile to use now, as well as trying to make sure AIs don't use them in less efficient ways (but the human players may find some more creative ways, in particular if they know what they are doing or if they find it fun i mean).

edit: tested a few games not a lot in autoplay and this seems to work fine
Note that in autoplay the AI overestimates a bit the total strength (due to these scouts additions?) if i am not mistaken, and maybe turtles a bit too much early i don't know, but the human player should (i think) be able to have a better economy early and have a stronger early game, and if AI vs AI they all have free scouts so should be about fine i think.